### PR TITLE
added optional closure to get() and delete() methods in RESTClient

### DIFF
--- a/src/main/groovy/wslite/rest/RESTClient.groovy
+++ b/src/main/groovy/wslite/rest/RESTClient.groovy
@@ -41,12 +41,12 @@ class RESTClient {
         this.httpClient.authorization = authorization
     }
 
-    Response get(Map params=[:]) {
-        return executeMethod(HTTPMethod.GET, params)
+    Response get(Map params=[:], Closure content=null) {
+        return executeMethod(HTTPMethod.GET, params, content)
     }
 
-    Response delete(Map params=[:]) {
-        return executeMethod(HTTPMethod.DELETE, params)
+    Response delete(Map params=[:], Closure content=null) {
+        return executeMethod(HTTPMethod.DELETE, params, content)
     }
 
     Response post(Map params=[:], Closure content) {


### PR DESCRIPTION
Having ran into an API that insisted on sending data in the GET request body, I modified the RESTClient.get() and delete() to take an optional content closure.  

This is a very minor change, with the default behavior remaining unchanged, but helps the library be more flexible for the future.
