### PR TITLE
Accept JSON with HAL hypermedia extensions as JSON

### DIFF
--- a/src/main/groovy/wslite/rest/ContentType.groovy
+++ b/src/main/groovy/wslite/rest/ContentType.groovy
@@ -15,7 +15,7 @@
 package wslite.rest
 
 enum ContentType {
-    JSON(['application/json', 'application/javascript', 'text/javascript', 'text/json']),
+    JSON(['application/json', 'application/hal+json', 'application/javascript', 'text/javascript', 'text/json']),
     XML(['application/xml', 'text/xml', 'application/xhtml+xml', 'application/atom+xml']),
     HTML(['text/html']),
     URLENC(['application/x-www-form-urlencoded']),


### PR DESCRIPTION
While playing this [API game](http://apibunny.com/), I noticed `application/hal+json` wasn't recognized as JSON payloads. It's a content type of JSON accepting the [HAL hypermedia extensions](http://stateless.co/hal_specification.html).