### PR TITLE
token base authorization

### DIFF
--- a/src/main/groovy/wslite/http/auth/HTTPTokenAuthorization.groovy
+++ b/src/main/groovy/wslite/http/auth/HTTPTokenAuthorization.groovy
@@ -1,0 +1,57 @@
+/* Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wslite.http.auth
+
+import wslite.http.HTTP
+import wslite.util.ObjectHelper
+
+class HTTPTokenAuthorization implements HTTPAuthorization {
+
+    String token
+
+    private String authorization
+
+    HTTPTokenAuthorization() { }
+
+    HTTPTokenAuthorization(String token) {
+        setToken(token)
+    }
+
+    void setToken(String token) {
+        this.token = token
+        authorization = null
+    }
+
+    String getToken() {
+        return token
+    }
+
+    void authorize(conn) {
+        conn.addRequestProperty(HTTP.AUTHORIZATION_HEADER, getAuthorization())
+    }
+
+    private String getAuthorization() {
+        if (!authorization) {
+            authorization = token
+        }
+        return authorization
+    }
+
+    @Override
+    String toString() {
+        ObjectHelper.dump(this, include:['token'])
+    }
+
+}


### PR DESCRIPTION
Hi 
I've added a HTTPTokenAuthorization class allowing me to authorize with an existing token by setting the Authorization header field directly.
It was an easy change and helped me to authenticate against my server infrastructure.
Regards, Martin