### PR TITLE
fix missing gradle properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,12 @@
+ext.mavenUsername = project.hasProperty("mavenUsername") ? mavenUsername : null
+ext.mavenUsername = project.hasProperty("mavenPassword") ? mavenPassword : null
+ext.signing = project.hasProperty("signing") ? signing : [:]
+ext.signing.secretKeyRingFile = project.hasProperty("signing.secretKeyRingFile") ? signing.secretKeyRingFile : null
+ext.signing.keyId = project.hasProperty("signing.keyId") ? signing.keyId : null
+ext.signing.password = project.hasProperty("signing.password") ? signing.password : null
+ext.githubUsername = project.hasProperty("githubUsername") ? githubUsername : null
+ext.githubPassword = project.hasProperty("githubPassword") ? githubPassword : null
+
 apply plugin: 'groovy'
 apply plugin: 'maven'
 apply plugin: 'signing'


### PR DESCRIPTION
Build Instructions not work, because need add gradle.properties manually. It is not big problem but git clone && gradle test  - fails.

A problem occurred evaluating root project 'groovy-wslite'.
> Could not find property 'githubUsername' on task ':integrationTest'.

Pull Request init missing properties with null values.