### PR TITLE
Make all exceptions runtime.

### DIFF
--- a/src/main/groovy/wslite/http/HTTPClientException.java
+++ b/src/main/groovy/wslite/http/HTTPClientException.java
@@ -14,7 +14,7 @@
  */
 package wslite.http;
 
-public class HTTPClientException extends Exception {
+public class HTTPClientException extends RuntimeException {
 
     private HTTPRequest request;
     private HTTPResponse response;


### PR DESCRIPTION
It's easy to get complacent in Groovy with regards to checked and unchecked
exceptions, but there are certain situations where the difference rears its
ugly head. In my case, Groovy was wrapping the HTTPClientException with an
UndeclaredThrowableException from a Spock test because the former is a checked
exception but `RESTClient.get()` doesn't declare that it throws it.

One solution is to make the affected methods declare that they throw the
exception, but I just prefer to make the exceptions runtime. Thus they don't
need to be declared.