### PR TITLE
Defer use of GitHub project properties.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,8 +51,6 @@ task groovydocJar(type: Jar, dependsOn: groovydoc) {
 task integrationTest(type: Test) {
     testClassesDir = sourceSets.integrationTest.output.classesDir
     classpath = sourceSets.integrationTest.runtimeClasspath
-    systemProperties['github.username'] = githubUsername
-    systemProperties['github.password'] = githubPassword
 }
 
 tasks.withType(CodeNarc) {
@@ -118,6 +116,18 @@ uploadArchives {
                 }
             }
         }
+    }
+}
+
+gradle.taskGraph.whenReady { graph ->
+    if (graph.hasTask(':integrationTest')) {
+        if (!project.hasProperty('githubUsername') || !project.hasProperty('githubPassword')) {
+            throw new GradleException("The integration tests require you to provide both 'githubUsername'" +
+                    " and 'githubPassword' project properties in order to run.")
+        }
+
+        integrationTest.systemProperties['github.username'] = githubUsername
+        integrationTest.systemProperties['github.password'] = githubPassword
     }
 }
 


### PR DESCRIPTION
The Gradle build cannot be imported into an IDE unless the `githubUsername` and
`githubPassword` project properties are defined. This kind of behaviour puts off
potential contributors, particularly as they may not realise why there is a
problem.

This fixes the issue by deferring the use of the GitHub properties until it's
known that they are actually required, i.e. if the integration tests are to be
run. In addition, if the properties are needed but not provided, the build now
generates an appropriate error message.