### PR TITLE
Custom content types

### DIFF
--- a/src/integrationTest/groovy/wslite/rest/RESTClientIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wslite/rest/RESTClientIntegrationSpec.groovy
@@ -25,10 +25,10 @@ class RESTClientIntegrationSpec extends Specification {
 
         then:
         200 == response.statusCode
-        'text/xml' == response.contentType
+        'application/rss+xml' == response.contentType
         'UTF-8' == response.charset
-        'text/xml; charset=UTF-8' == response.headers."Content-Type"
-        'FresnoStateNews.com' == response.xml.channel.title.text()
+        'application/rss+xml; charset=UTF-8' == response.headers."Content-Type"
+        'Fresno State News' == response.xml.channel.title.text()
     }
 
     void 'FresnoStateNews.com head request'() {

--- a/src/main/groovy/wslite/rest/ContentType.groovy
+++ b/src/main/groovy/wslite/rest/ContentType.groovy
@@ -30,6 +30,21 @@ enum ContentType {
         return contentTypes
     }
 
+    boolean contains(String contentType) {
+        boolean result = contentType in contentTypes
+        if (!result) {
+            switch (this) {
+                case JSON:
+                    result = contentType ==~ /application\/.*\+json/
+                    break;
+                case XML:
+                    result = contentType ==~ /application\/.*\+xml/
+                    break;
+            }
+        }
+        return result
+    }
+
     @Override
     String toString() {
         return contentTypes.first()

--- a/src/main/groovy/wslite/rest/ResponseBuilder.groovy
+++ b/src/main/groovy/wslite/rest/ResponseBuilder.groovy
@@ -42,18 +42,18 @@ class ResponseBuilder {
     private boolean isTextResponse(HTTPResponse httpResponse) {
         def contentType = contentTypeNoParameter(httpResponse)
         return contentType?.startsWith('text/') ||
-               contentType in ( ContentType.TEXT.getContentTypeList() +
-                                             ContentType.HTML.getContentTypeList() +
-                                             ContentType.XML.getContentTypeList()  +
-                                             ContentType.JSON.getContentTypeList() )
+                ContentType.TEXT.contains(contentType) ||
+                ContentType.HTML.contains(contentType) ||
+                ContentType.XML.contains(contentType) ||
+                ContentType.JSON.contains(contentType)
     }
 
     private boolean isXmlResponse(HTTPResponse httpResponse) {
-        return contentTypeNoParameter(httpResponse) in ContentType.XML.getContentTypeList()
+        return ContentType.XML.contains(contentTypeNoParameter(httpResponse))
     }
 
     private boolean isJsonResponse(HTTPResponse httpResponse) {
-        return contentTypeNoParameter(httpResponse) in ContentType.JSON.getContentTypeList()
+        return ContentType.JSON.contains(contentTypeNoParameter(httpResponse))
     }
 
     private parseXmlContent(String content) {

--- a/src/test/groovy/wslite/rest/ContentTypeSpec.groovy
+++ b/src/test/groovy/wslite/rest/ContentTypeSpec.groovy
@@ -1,0 +1,32 @@
+package wslite.rest
+
+import spock.lang.Specification
+
+class ContentTypeSpec extends Specification {
+
+    void 'json content type matches predefined types or custom media types'() {
+        expect:
+        ContentType.JSON.contains(type) == result
+
+        where:
+        type | result
+        'application/json' | true
+        'application/javascript' | true
+        'text/javascript' | true
+        'text/json' | true
+        'application/vnd.github.v3+json' | true
+    }
+
+    void 'xml content type matches predefined types or custom media types'() {
+        expect:
+        ContentType.XML.contains(type) == result
+
+        where:
+        type | result
+        'application/atom+xml' | true
+        'application/xhtml+xml' | true
+        'text/xml' | true
+        'application/xml' | true
+        'application/rss+xml' | true
+    }
+}


### PR DESCRIPTION
Hello John!

Some services put additional information in Content-Type header. 
Instead of `application/json` we can see `application/some.description.here+json` and so on.
It's still json content type but it hard to check with inclusion.
At the first time I've seen it working with Artifactory's REST API.

Here I add check for that situation with regexp and fix integration test waiting for patch:)

Best regards, Nick.