### PR TITLE
Proposed implementation for #130

### DIFF
--- a/src/main/groovy/wslite/http/HTTPClient.groovy
+++ b/src/main/groovy/wslite/http/HTTPClient.groovy
@@ -31,6 +31,10 @@ class HTTPClient {
     Proxy proxy
 
     def defaultHeaders = [Connection:'Close', 'Accept-Encoding':'gzip']
+    def authRequired = [
+        HttpURLConnection.HTTP_UNAUTHORIZED,
+        HttpURLConnection.HTTP_FORBIDDEN
+    ]
 
     HTTPConnectionFactory httpConnectionFactory
     HTTPAuthorization authorization
@@ -58,8 +62,24 @@ class HTTPClient {
                 throw new HTTPClientException(ex.message, ex, request, response)
             } else {
                 response = buildResponse(conn, conn.errorStream)
-                throw new HTTPClientException(response.statusCode + ' ' + response.statusMessage,
+                if (response.statusCode in authRequired && authorization instanceof HTTPAuthenticator) {
+                    HTTPAuthenticator authenticator = (HTTPAuthenticator)authorization
+                    if (authenticator.authenticate()) {
+                        try {
+                            conn?.disconnect()
+                            conn = createConnection(request)
+                            setupConnection(conn, request)
+                            response = buildResponse(conn, conn.inputStream)
+                        } catch (Exception nested) {
+                            response = buildResponse(conn, conn.errorStream)
+                            throw new HTTPClientException(response.statusCode + ' ' + response.statusMessage,
+                                nested, request, response)
+                        }
+                    }
+                } else {
+                    throw new HTTPClientException(response.statusCode + ' ' + response.statusMessage,
                         ex, request, response)
+                }
             }
         } finally {
             conn?.disconnect()

--- a/src/main/groovy/wslite/http/HTTPClient.groovy
+++ b/src/main/groovy/wslite/http/HTTPClient.groovy
@@ -32,8 +32,7 @@ class HTTPClient {
 
     def defaultHeaders = [Connection:'Close', 'Accept-Encoding':'gzip']
     def authRequired = [
-        HttpURLConnection.HTTP_UNAUTHORIZED,
-        HttpURLConnection.HTTP_FORBIDDEN
+        HttpURLConnection.HTTP_UNAUTHORIZED
     ]
 
     HTTPConnectionFactory httpConnectionFactory
@@ -64,17 +63,16 @@ class HTTPClient {
                 response = buildResponse(conn, conn.errorStream)
                 if (response.statusCode in authRequired && authorization instanceof HTTPAuthenticator) {
                     HTTPAuthenticator authenticator = (HTTPAuthenticator)authorization
-                    if (authenticator.authenticate()) {
-                        try {
-                            conn?.disconnect()
-                            conn = createConnection(request)
-                            setupConnection(conn, request)
-                            response = buildResponse(conn, conn.inputStream)
-                        } catch (Exception nested) {
-                            response = buildResponse(conn, conn.errorStream)
-                            throw new HTTPClientException(response.statusCode + ' ' + response.statusMessage,
-                                nested, request, response)
-                        }
+                    authenticator.authenticate()
+                    try {
+                        conn?.disconnect()
+                        conn = createConnection(request)
+                        setupConnection(conn, request)
+                        response = buildResponse(conn, conn.inputStream)
+                    } catch (Exception nested) {
+                        response = buildResponse(conn, conn.errorStream)
+                        throw new HTTPClientException(response.statusCode + ' ' + response.statusMessage,
+                            nested, request, response)
                     }
                 } else {
                     throw new HTTPClientException(response.statusCode + ' ' + response.statusMessage,

--- a/src/main/groovy/wslite/http/auth/HTTPAuthenticator.groovy
+++ b/src/main/groovy/wslite/http/auth/HTTPAuthenticator.groovy
@@ -1,6 +1,7 @@
 package wslite.http.auth
 
+import wslite.http.HTTPClientException
 
 interface HTTPAuthenticator {
-    boolean authenticate()
+    boolean authenticate() throws HTTPClientException
 }

--- a/src/main/groovy/wslite/http/auth/HTTPAuthenticator.groovy
+++ b/src/main/groovy/wslite/http/auth/HTTPAuthenticator.groovy
@@ -1,0 +1,6 @@
+package wslite.http.auth
+
+
+interface HTTPAuthenticator {
+    boolean authenticate()
+}


### PR DESCRIPTION
I have a test case for this, but it is based on an internal corporate system, so apart from potentially being confidential, it's also useless for anybody else.

If anybody has any suggestion for a publicly available service that requires something like:
1. Invoke a specific URL to authenticate which returns a token (possibly a cookie)
2. Subsequent requests need to have the token included (either as Authorization header or as a cookie)

I would really appreciate any pointers so that I can provide an integration test case that makes sense outside of my own organization.
